### PR TITLE
fix checksum failure with shasum

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -78,9 +78,9 @@ checksumbin=$(command -v openssl) || checksumbin=$(command -v shasum) || {
 my_mktemp () {
 	local tempdir=""
 	if [ "linux" = "$1" ] ; then
-		tempdir=$(mktemp -d asdf-helm.XXXX)
+		tempdir=$(mktemp -d asdf-linkerd.XXXX)
 	else
-		tempdir=$(mktemp -dt asdf-helm.XXXX)
+		tempdir=$(mktemp -dt asdf-linkerd.XXXX)
 	fi
 	echo -n $tempdir
 }

--- a/bin/install
+++ b/bin/install
@@ -58,7 +58,7 @@ validate_checksum() {
       checksum=$($checksumbin dgst -sha256 "${filename}" | sed -e 's/^.* //')
       ;;
     *shasum)
-      checksum=$($checksumbin -a256 "${filename}" | sed -e 's/^.* //')
+      checksum=$($checksumbin -a256 "${filename}" | sed -e 's/ .*$//')
       ;;
   esac
 


### PR DESCRIPTION
Currently, shasum seems not working because of the sed command (which removes the wrong part of the returned string).

This PR fix this issue. (I use shasum on Ubuntu 20.04)