### PR TITLE
Fix missing arch on src_file path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ linkerd plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 ## Install
 
 ```
-asdf plugin-add linkerd https://github.com/team-gary/asdf-linkerd.git
+asdf plugin-add linkerd https://github.com/bryncooke/asdf-linkerd.git
 ```
 
 ## Use

--- a/bin/install
+++ b/bin/install
@@ -78,9 +78,9 @@ checksumbin=$(command -v openssl) || checksumbin=$(command -v shasum) || {
 my_mktemp () {
 	local tempdir=""
 	if [ "linux" = "$1" ] ; then
-		tempdir=$(mktemp -d asdf-helm.XXXX)
+		tempdir=$(mktemp -d asdf-linkerd.XXXX)
 	else
-		tempdir=$(mktemp -dt asdf-helm.XXXX)
+		tempdir=$(mktemp -dt asdf-linkerd.XXXX)
 	fi
 	echo -n $tempdir
 }
@@ -93,6 +93,9 @@ install_linkerd () {
 	local arch=$(get_arch)
 	local tempdir=$(my_mktemp $platform)
 	local src_file="linkerd2-cli-stable-${version}-${platform}"
+	if [ "linux" = "${platform}" ] ; then
+	  src_file="${src_file}-${arch}"
+	fi
 	local download_url=$(get_download_url $version $src_file)
 	local bin_install_path="${install_path}/bin"
 


### PR DESCRIPTION
Since linkerd 2.9.1 arch has been included in the download filename if the platform is linux. Support for prior versions has been dropped. 
Also change tempdir name